### PR TITLE
fix: enhance printing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import chalk from "chalk";
 import { type ParsedFailure } from "parsers/types";
 
+import pkg from "../package.json";
 import { stepConfig } from "./config";
 import {
   decorateLabel,
@@ -117,7 +118,11 @@ function render() {
   if (process.stdout.isTTY) {
     console.clear();
   }
-  console.log("Running project checks:\n");
+  console.log(
+    chalk.bold(`${pkg.name} v${pkg.version}`) +
+      " — Validating your code quality"
+  );
+  console.log();
   if (isLooseMode) {
     console.log(
       "(* indicates loose mode; some rules are disabled or set to warnings)\n"


### PR DESCRIPTION
Enhances the printed text, and adds a --silent flag to hide the failure output.