### PR TITLE
fix: improve rendering of failure details and update function signatures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,7 @@ async function main() {
   );
   suiteFinished = true;
   suiteDurationMs = Date.now() - suiteStartTime;
-  render(runOptions);
-  printFailureDetails(failures, runOptions);
+  render(runOptions, failures.length > 0 ? failures : null);
   process.exit(failures.length > 0 ? 1 : 0);
 }
 
@@ -114,12 +113,15 @@ function recordIssueCounts(parsedFailure?: ParsedFailure | null) {
   totalWarnings += warnings;
 }
 
-function render(runOptions: RunOptions) {
+function render(
+  runOptions: RunOptions,
+  failures: FailureDetails[] | null = null
+) {
   if (process.stdout.isTTY) {
     console.clear();
   }
   console.log(
-    chalk.bold(`${pkg.name} v${pkg.version}`) +
+    chalk.bold(`\n${pkg.name} v${pkg.version}`) +
       " — Validating your code quality"
   );
   console.log();
@@ -128,6 +130,11 @@ function render(runOptions: RunOptions) {
       "(* indicates loose mode; some rules are disabled or set to warnings)\n"
     );
   }
+
+  if (failures) {
+    printFailureDetails(failures, runOptions);
+  }
+
   const rows = steps.map((step, idx) => {
     const status = statuses[idx];
     const message =

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -170,7 +170,7 @@ describe("printFailureDetails", () => {
 
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
-      "\nSome checks failed. Run without --silent to see details."
+      "Some checks failed. Run without --silent to see details."
     );
   });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -260,16 +260,18 @@ export const printFailureDetails = (
 ) => {
   if (failures.length > 0) {
     if (runOptions.isSilentMode) {
-      console.log("\nSome checks failed. Run without --silent to see details.");
+      console.log("Some checks failed. Run without --silent to see details.");
       return;
     }
 
-    console.log("\nDetails:");
+    console.log("Details:");
 
     failures.forEach((failure) => {
       const headline = formatFailureHeadline(failure);
       console.log(`\n${headline}`);
       console.log(failure.rawOutput || failure.output || "(no output)");
     });
+
+    console.log();
   }
 };


### PR DESCRIPTION
Makes it so that the summary is printed after the errors, that way it doesn't get sent off the top of the screen when there are a lot of errors.