### PR TITLE
chore: configure alias and prettier sorting settings

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
   trailingComma: "es5",
   semi: true,
   plugins: ["@trivago/prettier-plugin-sort-imports"],
-  importOrder: ["^node:", "<THIRD_PARTY_MODULES>", "^[./]"],
+  importOrder: ["^node:", "<THIRD_PARTY_MODULES>", "^@/", "^[./]"],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,10 @@
     "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["*"],
+      "@": ["."]
+    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Adds the `@` alias for `src/` for imports so that they can more easily reference the root.