### PR TITLE
fix: remove the concept of loose commands entirely

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,8 +84,6 @@ Run `npm run check` to validate all quality gates:
 6. **Knip** - No unused dependencies or exports
 7. **npm audit** - No known security vulnerabilities
 
-All checks must pass in strict mode (not loose mode).
-
 ### Individual Quality Checks
 
 - `npm run prettier` or `npm run prettier:fix`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,7 @@ Before every commit, run `npm run check` to validate all quality gates:
 6. **Knip** - No unused dependencies or exports
 7. **npm audit** - No known security vulnerabilities
 
-**All checks must pass in strict mode** (not loose mode) before your pull
-request will be accepted.
+**All checks must pass** before your pull request will be accepted.
 
 ### Individual Quality Checks
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ security checks in one dashboard.
 ## Usage
 
 ```sh
-is-it-ready [--loose] [--silent] [--fix] [--config <path>] [-h | --help] [-v | --version]
+is-it-ready [--silent] [--fix] [--config <path>] [-h | --help] [-v | --version]
 ```
 
 ### Flags
@@ -21,7 +21,6 @@ is-it-ready [--loose] [--silent] [--fix] [--config <path>] [-h | --help] [-v | -
 - `-v, --version` - Show version number.
 - `--config <path>` - Use a specific config file instead of searching defaults.
 - `--silent` - Keep the summary table but skip the detailed failure output.
-- `--loose` - Use the loose variant for tasks that support it (labels show `*`).
 - `--fix` - Automatically run fix commands for tasks that support it (labels
   show `*`).
 
@@ -42,8 +41,7 @@ for global support.
 - Pass `--config <path>` (e.g., `is-it-ready --config configs/staging.mjs`)
   to point the CLI at a specific file.
 - Each file must export an object with a `tasks` array. Every task entry must
-  specify the `tool` name and its `command`, and may provide `looseCommand` and
-  `fixCommand` overrides.
+  specify the `tool` name and its `command`, and may provide `fixCommand` overrides.
 
 Example `.is-it-ready.config.mjs`:
 
@@ -58,7 +56,6 @@ export default {
     {
       tool: "ESLint",
       command: "npm run lint",
-      looseCommand: "npm run lint -- --max-warnings 100",
     },
   ],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -163,7 +163,7 @@ export default defineConfig([
       "unused-imports/no-unused-vars": [
         "warn",
         {
-          args: "after-used",
+          args: "all",
           argsIgnorePattern: "^_",
           vars: "all",
           varsIgnorePattern: "^_",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "test": "vitest",
     "type-check": "tsc --noEmit",
     "check": "ts-node --transpile-only src/index.ts",
-    "check:loose": "ts-node --transpile-only src/index.ts --loose",
     "check:fix": "ts-node --transpile-only src/index.ts --fix"
   },
   "dependencies": {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -31,7 +31,6 @@ const cleanupDir = (directory: string) => {
 const makeRunOptions = (overrides: Partial<RunOptions> = {}): RunOptions => {
   return {
     isFixMode: false,
-    isLooseMode: false,
     isSilentMode: false,
     configPath: undefined,
     ...overrides,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -118,7 +118,6 @@ const isUserTaskConfig = (value: unknown): value is UserTaskConfig => {
   return (
     isNonEmptyString(value.tool) &&
     isNonEmptyString(value.command) &&
-    isOptionalString(value.looseCommand) &&
     isOptionalString(value.fixCommand)
   );
 };
@@ -159,7 +158,6 @@ const mergeTaskConfig = (userTask: UserTaskConfig): TaskConfig => {
     label: baseConfig.label,
     tool: baseConfig.tool,
     command: userTask.command,
-    looseCommand: userTask.looseCommand,
     fixCommand: userTask.fixCommand,
     parseFailure: baseConfig.parseFailure,
   };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,7 +1,6 @@
 export type UserTaskConfig = {
   tool: string;
   command: string;
-  looseCommand?: string;
   fixCommand?: string;
 };
 

--- a/src/helpers/helpers.test.ts
+++ b/src/helpers/helpers.test.ts
@@ -20,12 +20,10 @@ describe("decorateLabel", () => {
 
 describe("selectCommand", () => {
   const baseCommand = "npm run lint";
-  const looseCommand = "npm run lint:loose";
   const fixCommand = "npm run lint:fix";
 
-  const makeOptions = (isLoose: boolean, isFix: boolean): RunOptions => {
+  const makeOptions = (isFix: boolean): RunOptions => {
     return {
-      isLooseMode: isLoose,
       isFixMode: isFix,
       isSilentMode: false,
       configPath: undefined,
@@ -37,11 +35,10 @@ describe("selectCommand", () => {
       label: "Linting",
       tool: "ESLint",
       command: baseCommand,
-      looseCommand,
       fixCommand,
     } as TaskConfig;
 
-    const result = selectCommand(config, makeOptions(false, true));
+    const result = selectCommand(config, makeOptions(true));
 
     expect(result.command).toBe(fixCommand);
     expect(result.label).toBe("Linting*");
@@ -52,56 +49,10 @@ describe("selectCommand", () => {
       label: "Linting",
       tool: "ESLint",
       command: baseCommand,
-      looseCommand,
       fixCommand: undefined,
     } as TaskConfig;
 
-    const result = selectCommand(config, makeOptions(false, true));
-
-    expect(result.command).toBe(baseCommand);
-    expect(result.label).toBe("Linting");
-  });
-
-  it("prioritizes fix over loose", () => {
-    const config: TaskConfig = {
-      label: "Linting",
-      tool: "ESLint",
-      command: baseCommand,
-      looseCommand,
-      fixCommand,
-    } as TaskConfig;
-
-    const result = selectCommand(config, makeOptions(true, true));
-
-    expect(result.command).toBe(fixCommand);
-    expect(result.label).toBe("Linting*");
-  });
-
-  it("returns loose command when loose mode enabled", () => {
-    const config: TaskConfig = {
-      label: "Linting",
-      tool: "ESLint",
-      command: baseCommand,
-      looseCommand,
-      fixCommand,
-    } as TaskConfig;
-
-    const result = selectCommand(config, makeOptions(true, false));
-
-    expect(result.command).toBe(looseCommand);
-    expect(result.label).toBe("Linting*");
-  });
-
-  it("falls back to base when loose mode enabled but no loose command", () => {
-    const config: TaskConfig = {
-      label: "Linting",
-      tool: "ESLint",
-      command: baseCommand,
-      looseCommand: undefined,
-      fixCommand,
-    } as TaskConfig;
-
-    const result = selectCommand(config, makeOptions(true, false));
+    const result = selectCommand(config, makeOptions(true));
 
     expect(result.command).toBe(baseCommand);
     expect(result.label).toBe("Linting");
@@ -114,22 +65,7 @@ describe("selectCommand", () => {
       command: baseCommand,
     } as TaskConfig;
 
-    const result = selectCommand(config, makeOptions(false, false));
-
-    expect(result.command).toBe(baseCommand);
-    expect(result.label).toBe("Linting");
-  });
-
-  it("prioritizes fix mode over loose mode, even if fix isn't supported", () => {
-    const config: TaskConfig = {
-      label: "Linting",
-      tool: "ESLint",
-      command: baseCommand,
-      looseCommand,
-      fixCommand: undefined,
-    } as TaskConfig;
-
-    const result = selectCommand(config, makeOptions(true, true));
+    const result = selectCommand(config, makeOptions(false));
 
     expect(result.command).toBe(baseCommand);
     expect(result.label).toBe("Linting");

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -26,20 +26,11 @@ export const selectCommand = (
   toolConfig: TaskConfig,
   runOptions: RunOptions
 ): ExecutableCommand => {
-  if (runOptions.isFixMode) {
-    if (toolConfig.fixCommand) {
-      return {
-        label: decorateLabel(toolConfig.label),
-        command: toolConfig.fixCommand,
-      };
-    }
-  } else if (runOptions.isLooseMode) {
-    if (toolConfig.looseCommand) {
-      return {
-        label: decorateLabel(toolConfig.label),
-        command: toolConfig.looseCommand,
-      };
-    }
+  if (runOptions.isFixMode && toolConfig.fixCommand) {
+    return {
+      label: decorateLabel(toolConfig.label),
+      command: toolConfig.fixCommand,
+    };
   }
 
   return { label: toolConfig.label, command: toolConfig.command };

--- a/src/renderers/render.test.ts
+++ b/src/renderers/render.test.ts
@@ -147,7 +147,6 @@ describe("printFailureDetails", () => {
     rawOutput: "raw output",
   };
   const baseRunOptions = {
-    isLooseMode: false,
     isSilentMode: false,
     isFixMode: false,
     configPath: undefined,

--- a/src/renderers/render.ts
+++ b/src/renderers/render.ts
@@ -288,10 +288,6 @@ export const render = (tasks: Task[], runOptions: RunOptions) => {
     console.log(
       "(* indicates fix mode; some tasks will automatically apply fixes to your code)\n"
     );
-  } else if (runOptions.isLooseMode) {
-    console.log(
-      "(* indicates loose mode; some rules are disabled or set to warnings)\n"
-    );
   }
 
   const suiteFinished = tasks.every((task) => {

--- a/src/runOptions/help.md
+++ b/src/runOptions/help.md
@@ -6,7 +6,7 @@ security checks in one dashboard.
 ## Usage
 
 ```sh
-is-it-ready [--loose] [--silent] [--fix] [--config <path>] [-h | --help] [-v | --version]
+is-it-ready [--silent] [--fix] [--config <path>] [-h | --help] [-v | --version]
 ```
 
 ### Flags
@@ -15,7 +15,6 @@ is-it-ready [--loose] [--silent] [--fix] [--config <path>] [-h | --help] [-v | -
 - `-v, --version` - Show version number.
 - `--config <path>` - Use a specific config file instead of searching defaults.
 - `--silent` - Keep the summary table but skip the detailed failure output.
-- `--loose` - Use the loose variant for tasks that support it (labels show `*`).
 - `--fix` - Automatically run fix commands for tasks that support it (labels
   show `*`).
 
@@ -36,8 +35,7 @@ for global support.
 - Pass `--config <path>` (e.g., `is-it-ready --config configs/staging.mjs`)
   to point the CLI at a specific file.
 - Each file must export an object with a `tasks` array. Every task entry must
-  specify the `tool` name and its `command`, and may provide `looseCommand` and
-  `fixCommand` overrides.
+  specify the `tool` name and its `command`, and may provide `fixCommand` overrides.
 
 Example `.is-it-ready.config.mjs`:
 
@@ -52,7 +50,6 @@ export default {
     {
       tool: "ESLint",
       command: "npm run lint",
-      looseCommand: "npm run lint -- --max-warnings 100",
     },
   ],
 };

--- a/src/runOptions/runOptions.test.ts
+++ b/src/runOptions/runOptions.test.ts
@@ -21,17 +21,6 @@ describe("getRunOptions", () => {
   it("returns false flags when options omitted", () => {
     process.argv = ["node", "script.js"];
     expect(getRunOptions()).toEqual({
-      isLooseMode: false,
-      isSilentMode: false,
-      isFixMode: false,
-      configPath: undefined,
-    });
-  });
-
-  it("enables loose mode when --loose passed", () => {
-    process.argv = ["node", "script.js", "--loose"];
-    expect(getRunOptions()).toEqual({
-      isLooseMode: true,
       isSilentMode: false,
       isFixMode: false,
       configPath: undefined,
@@ -41,7 +30,6 @@ describe("getRunOptions", () => {
   it("enables silent mode when --silent passed", () => {
     process.argv = ["node", "script.js", "--silent"];
     expect(getRunOptions()).toEqual({
-      isLooseMode: false,
       isSilentMode: true,
       isFixMode: false,
       configPath: undefined,
@@ -49,11 +37,10 @@ describe("getRunOptions", () => {
   });
 
   it("enables both flags when both arguments supplied", () => {
-    process.argv = ["node", "script.js", "--silent", "--loose"];
+    process.argv = ["node", "script.js", "--silent", "--fix"];
     expect(getRunOptions()).toEqual({
-      isLooseMode: true,
       isSilentMode: true,
-      isFixMode: false,
+      isFixMode: true,
       configPath: undefined,
     });
   });
@@ -62,7 +49,6 @@ describe("getRunOptions", () => {
     process.argv = ["node", "script.js", "--config", "custom.config.js"];
 
     expect(getRunOptions()).toEqual({
-      isLooseMode: false,
       isSilentMode: false,
       isFixMode: false,
       configPath: "custom.config.js",
@@ -73,7 +59,6 @@ describe("getRunOptions", () => {
     process.argv = ["node", "script.js", "--config=custom.mjs"];
 
     expect(getRunOptions()).toEqual({
-      isLooseMode: false,
       isSilentMode: false,
       isFixMode: false,
       configPath: "custom.mjs",

--- a/src/runOptions/runOptions.ts
+++ b/src/runOptions/runOptions.ts
@@ -14,7 +14,6 @@ import { type RunOptions } from "./types";
 export const getRunOptions = (): RunOptions => {
   const args = process.argv.slice(2);
 
-  let isLooseMode = false;
   let isSilentMode = false;
   let isFixMode = false;
   let configPath: string | undefined;
@@ -59,10 +58,6 @@ export const getRunOptions = (): RunOptions => {
       continue;
     }
 
-    if (arg === "--loose") {
-      isLooseMode = true;
-    }
-
     if (arg === "--silent") {
       isSilentMode = true;
     }
@@ -72,7 +67,7 @@ export const getRunOptions = (): RunOptions => {
     }
   }
 
-  return { isLooseMode, isSilentMode, isFixMode, configPath };
+  return { isSilentMode, isFixMode, configPath };
 };
 
 export const printHelp = () => {

--- a/src/runOptions/types.ts
+++ b/src/runOptions/types.ts
@@ -1,5 +1,4 @@
 export type RunOptions = {
-  isLooseMode: boolean;
   isSilentMode: boolean;
   isFixMode: boolean;
   configPath: string | undefined;

--- a/src/task/defaultTasks.ts
+++ b/src/task/defaultTasks.ts
@@ -21,7 +21,6 @@ export const taskConfig: TaskConfig[] = [
     label: "Linting",
     tool: "ESLint",
     command: "npm run lint",
-    looseCommand: "npm run lint:loose",
     fixCommand: "npm run lint:fix",
     parseFailure: parseEslint,
   },
@@ -36,7 +35,6 @@ export const taskConfig: TaskConfig[] = [
     label: "Type Checking",
     tool: "TypeScript",
     command: "npm run type-check",
-    looseCommand: "npm run type-check:loose",
     parseFailure: parseTypeCheck,
   },
   {
@@ -49,7 +47,6 @@ export const taskConfig: TaskConfig[] = [
     label: "Inventory",
     tool: "Knip",
     command: "npm run knip",
-    looseCommand: "npm run knip:loose",
     fixCommand: "npm run knip:fix",
     parseFailure: parseKnip,
   },

--- a/src/task/task.test.ts
+++ b/src/task/task.test.ts
@@ -13,7 +13,6 @@ export const createMockTask = (
       label: "Echo Task",
       tool: "Echo",
       command: "echo 'Echo command'",
-      looseCommand: "echo 'Echo command loose'",
       fixCommand: "echo 'Echo command fix'",
       parseFailure: () => {
         return undefined;
@@ -22,7 +21,6 @@ export const createMockTask = (
     },
     {
       isFixMode: false,
-      isLooseMode: false,
       isSilentMode: false,
       configPath: undefined,
       ...optionsOverrides,
@@ -58,38 +56,6 @@ describe("Task", () => {
     expect(result).toBeUndefined();
     expect(runCommandSpy).toHaveBeenCalledWith("echo 'Echo command'");
     expect(commandOutput.trim()).toBe("Echo command");
-  });
-
-  it("runs the loose task when triggering the execute method", async () => {
-    const runCommandSpy = vi.spyOn(helpers, "runCommand").mockResolvedValue({
-      status: 0,
-      stdout: "Echo command loose\n",
-      stderr: "",
-    });
-    let commandOutput = "";
-
-    const task = createMockTask(
-      {
-        parseFailure: (output) => {
-          commandOutput = output;
-
-          return undefined;
-        },
-      },
-      {
-        isLooseMode: true,
-      }
-    );
-
-    expect(task.label).toBe("Echo Task*");
-    expect(task.command).toBe("echo 'Echo command loose'");
-    expect(task.tool).toBe("Echo");
-
-    const result = await task.execute();
-
-    expect(result).toBeUndefined();
-    expect(runCommandSpy).toHaveBeenCalledWith("echo 'Echo command loose'");
-    expect(commandOutput.trim()).toBe("Echo command loose");
   });
 
   it("runs the fix task when triggering the execute method", async () => {

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -12,7 +12,6 @@ export type TaskConfig = {
   label: string;
   tool: string;
   command: string;
-  looseCommand?: string;
   fixCommand?: string;
   parseFailure: (output: string) => ParsedFailure | undefined;
 };


### PR DESCRIPTION
# Pull Request

## Summary

The concept of loose commands is an opinionated one and does not belong inside this package.

## Reasoning

### Why is this change needed?

By enforcing the concept of loose commands, it complicates the interplay between the base and fix commands (should there be a loose and loose-fix command?), and generally makes the logic trickier to understand intuitively. It is also something that can easily be replicated externally by the consumer by creating separate configs and binding them to separate npm scripts.

### What are the benefits?

Easier to maintain without, and it's an unnecessary complication.
