### PR TITLE
Fix overall duration by using earliest task start time ([Bug]: Incorrect total duration #56)

### DIFF
--- a/src/renderers/render.ts
+++ b/src/renderers/render.ts
@@ -335,7 +335,10 @@ export const render = (tasks: Task[], runOptions: RunOptions) => {
         const end = task.getEndTime();
 
         if (start !== null && end !== null) {
-          acc.suiteStartTime = Math.max(acc.suiteStartTime, start);
+          acc.suiteStartTime =
+            acc.suiteStartTime === 0
+              ? start
+              : Math.min(acc.suiteStartTime, start);
           acc.suiteEndTime = Math.max(acc.suiteEndTime, end);
         }
 


### PR DESCRIPTION
## Summary

Fixes the overall duration calculation to use the earliest task start time.
Resolved issue: **[Bug]: Incorrect total duration #56**

---

## Reasoning

The overall duration was calculated using the latest task start time, which caused the total time to be slightly incorrect when tasks started at different times; this was resolved by using the first (earliest) task start time instead.

---

## Screenshots

<img width="658" height="360" alt="correct-timing" src="https://github.com/user-attachments/assets/58d6a3cd-638d-4adf-89d8-758b06e4fb84" />

