### PR TITLE
fix: resolve incorrect npm audit error reporting

### DIFF
--- a/src/task/parsers/npm-audit/parser.test.ts
+++ b/src/task/parsers/npm-audit/parser.test.ts
@@ -45,4 +45,13 @@ describe("parseNpmAudit", () => {
       errors: 13,
     });
   });
+
+  it("reports severity-only summaries", () => {
+    const output = "2 moderate severity vulnerabilities";
+
+    expect(parseNpmAudit(output)).toEqual({
+      message: "Failed - 2 vulnerabilities (2 moderate)",
+      errors: 2,
+    });
+  });
 });

--- a/src/task/parsers/npm-audit/parser.ts
+++ b/src/task/parsers/npm-audit/parser.ts
@@ -1,6 +1,23 @@
 import { type ParsedFailure } from "~/task/types";
 
 export const parseNpmAudit = (output: string): ParsedFailure | undefined => {
+  const severitySummary =
+    /(\d+)\s+([a-z]+)\s+severity\s+vulnerabilities?/i.exec(output);
+  if (severitySummary) {
+    const total = Number(severitySummary[1]);
+    if (!Number.isFinite(total) || total === 0) {
+      return undefined;
+    }
+
+    const severity = severitySummary[2].trim();
+    return {
+      message: `Failed - ${total} ${
+        total === 1 ? "vulnerability" : "vulnerabilities"
+      } (${total} ${severity})`,
+      errors: total,
+    };
+  }
+
   const summaryRegex =
     /(?:found\s+)?(\d+)\s+(?:vulnerability|vulnerabilities)(?:\s+\(([^)]+)\))?/gi;
   const summary = summaryRegex.exec(output);


### PR DESCRIPTION
# Pull Request

## Summary

In some circumstances, `npm audit` would report in a different format, resulting in the parser not being able to extract the correct number of errors out of it.

## Screenshots (Optional)

Before:
<img width="662" height="271" alt="image" src="https://github.com/user-attachments/assets/5a01a931-478b-495c-97f5-8962e4e15f9e" />

After:
<img width="828" height="271" alt="image" src="https://github.com/user-attachments/assets/c3f26097-ed72-4875-b1f9-c5d0471dc6b5" />

Note that in both cases, `npm audit` reported two moderate vulnerabilities.