### PR TITLE
feat: allow tools to be used even without a parser provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ for global support.
   to point the CLI at a specific file.
 - Each file must export an object with a `tasks` array. Every task entry must
   specify the `tool` name and its `command`, and may provide `fixCommand` overrides.
+- Built-in tools get parser-based issue counts. Other tool names are allowed,
+  but they run in exit-code-only mode and show a warning that they are not
+  directly supported.
 
 Example `.is-it-ready.config.mjs`:
 
@@ -78,7 +81,7 @@ export default {
 
 ### Tool support
 
-Currently, this tool only provides support for the following packages/tools:
+Currently, this tool provides direct parser support for the following tools:
 
 - ESLint
 - Knip
@@ -87,9 +90,13 @@ Currently, this tool only provides support for the following packages/tools:
 - TypeScript
 - Vitest
 
-It also provides support for some npm commands
+It also provides direct parser support for some npm commands:
 
 - npm audit
+
+Other tools may still be configured. When a tool has no built-in parser,
+`is-it-ready` warns once and uses only the command exit code to decide whether
+that task passed or failed.
 
 ## Contributing
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -96,7 +96,7 @@ describe("loadUserConfig", () => {
     cleanupDir(directory);
   });
 
-  it("throws when the tool referenced does not exist", async () => {
+  it("accepts unknown tools and configures them for exit-code-only mode", async () => {
     const directory = withTempDir(`
       module.exports = {
         tasks: [
@@ -108,9 +108,48 @@ describe("loadUserConfig", () => {
       };
     `);
 
-    await expect(loadUserConfig(makeRunOptions())).rejects.toThrowError(
-      /unknown tool/i
-    );
+    const config = await loadUserConfig(makeRunOptions());
+
+    expect(config).not.toBeNull();
+    expect(config?.unsupportedTools).toEqual(["Unknown"]);
+    expect(config?.tasks).toHaveLength(1);
+    expect(config?.tasks[0]?.label).toBe("Unknown");
+    expect(config?.tasks[0]?.tool).toBe("Unknown");
+    expect(config?.tasks[0]?.command).toBe("npm run foo");
+    expect(config?.tasks[0]?.usesExitCodeOnly).toBe(true);
+    expect(config?.tasks[0]?.parseFailure("some output")).toBeUndefined();
+
+    cleanupDir(directory);
+  });
+
+  it("deduplicates unsupported tool warnings across multiple tasks", async () => {
+    const directory = withTempDir(`
+      module.exports = {
+        tasks: [
+          {
+            tool: "Unknown",
+            command: "npm run foo"
+          },
+          {
+            tool: "Prettier",
+            command: "npm run prettier"
+          },
+          {
+            tool: "Unknown",
+            command: "npm run foo:again"
+          },
+          {
+            tool: "Another",
+            command: "npm run bar"
+          }
+        ]
+      };
+    `);
+
+    const config = await loadUserConfig(makeRunOptions());
+
+    expect(config).not.toBeNull();
+    expect(config?.unsupportedTools).toEqual(["Unknown", "Another"]);
 
     cleanupDir(directory);
   });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,15 @@ const explorer = cosmiconfig("is-it-ready", {
 });
 
 /**
+ * Returns no parsed failure details for unsupported tools.
+ *
+ * @returns {undefined} Always undefined so exit code drives task success/failure.
+ */
+function parseUnsupportedFailure() {
+  return undefined;
+}
+
+/**
  * Get the user configuration for the project.
  *
  * @param {string} rootDirectory - The root directory of the project.
@@ -152,9 +161,14 @@ const mergeTaskConfig = (userTask: UserTaskConfig): TaskConfig => {
   const baseConfig = DEFAULT_TASKS.get(userTask.tool);
 
   if (!baseConfig) {
-    throw new Error(
-      `Unknown tool "${userTask.tool}" found in .is-it-ready.config`
-    );
+    return {
+      label: userTask.tool,
+      tool: userTask.tool,
+      command: userTask.command,
+      fixCommand: userTask.fixCommand,
+      parseFailure: parseUnsupportedFailure,
+      usesExitCodeOnly: true,
+    };
   }
 
   return {
@@ -188,11 +202,20 @@ export const loadUserConfig = async (
   }
 
   const watchIgnore = exportedConfig.watchIgnore;
+  const unsupportedTools = Array.from(
+    new Set(
+      exportedConfig.tasks.flatMap((taskDefinition) => {
+        return DEFAULT_TASKS.has(taskDefinition.tool)
+          ? []
+          : [taskDefinition.tool];
+      })
+    )
+  );
 
   const tasks = exportedConfig.tasks.map((taskDefinition) => {
     const mergedConfig = mergeTaskConfig(taskDefinition);
     return new Task(mergedConfig, runOptions);
   });
 
-  return { watchIgnore, tasks };
+  return { watchIgnore, tasks, unsupportedTools };
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -14,4 +14,5 @@ export type UserFileConfig = {
 export type Config = {
   watchIgnore?: string[];
   tasks: Task[];
+  unsupportedTools: string[];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 
 import { loadUserConfig } from "./config";
 import { getRunOptions } from "./runOptions/runOptions";
-import { calculateTotalIssues, runTasks, startWatcher } from "./task";
+import { hasTaskFailures, runTasks, startWatcher } from "./task";
 
 void main().catch((error) => {
   console.error(chalk.red("Unexpected error while running tasks."));
@@ -35,9 +35,8 @@ async function main() {
 
   if (!runOptions.isWatchMode) {
     await runTasks(config, runOptions);
-    const totalIssues = calculateTotalIssues(config.tasks);
 
-    process.exit(totalIssues > 0 ? 1 : 0);
+    process.exit(hasTaskFailures(config.tasks) ? 1 : 0);
   }
 
   await runTasks(config, runOptions);

--- a/src/renderers/render.test.ts
+++ b/src/renderers/render.test.ts
@@ -205,10 +205,17 @@ describe("render", () => {
     isNoColor: false,
     configPath: undefined,
   };
+  const createConfig = (tasks: Task[], unsupportedTools: string[] = []) => {
+    return {
+      tasks,
+      unsupportedTools,
+    };
+  };
 
   type TaskDoubleInput = {
     label: string;
     tool: string;
+    usesExitCodeOnly?: boolean;
     state: "pending" | "running" | "success" | "failure";
     message: string;
     failures?: FailureDetails[];
@@ -222,6 +229,7 @@ describe("render", () => {
     return {
       label: input.label,
       tool: input.tool,
+      usesExitCodeOnly: input.usesExitCodeOnly ?? false,
       getStatus: () => {
         return { state: input.state, message: input.message };
       },
@@ -286,7 +294,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, { ...baseRunOptions, isWatchMode: true });
+    render(createConfig(tasks), { ...baseRunOptions, isWatchMode: true });
 
     expect(clearSpy).toHaveBeenCalledTimes(1);
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
@@ -334,7 +342,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(logSpy).not.toHaveBeenCalledWith("Details:");
   });
@@ -370,7 +378,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "❌ Overall",
@@ -406,7 +414,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, { ...baseRunOptions, isFixMode: true });
+    render(createConfig(tasks), { ...baseRunOptions, isFixMode: true });
 
     expect(logSpy).toHaveBeenCalledWith(
       "(* indicates fix mode; some tasks will automatically apply fixes to your code)\n"
@@ -444,7 +452,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "❌ Overall",
@@ -473,7 +481,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     const firstCall = logSpy.mock.calls[0] as [string] | undefined;
     const firstArg = firstCall?.[0];
@@ -489,14 +497,14 @@ describe("render", () => {
     });
 
     render(
-      [
+      createConfig([
         createTaskDouble({
           label: "Tests",
           tool: "Vitest",
           state: "success",
           message: "Passed",
         }),
-      ],
+      ]),
       baseRunOptions
     );
 
@@ -529,7 +537,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "✅ Overall",
@@ -557,7 +565,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "✅ Overall",
@@ -585,7 +593,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "❌ Overall",
@@ -628,7 +636,7 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "✅ Overall",
@@ -663,13 +671,182 @@ describe("render", () => {
       }),
     ];
 
-    render(tasks, baseRunOptions);
+    render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
       "✅ Overall",
       "",
       "0 issues",
       "1.0 s",
+    ]);
+  });
+
+  it("shows an amber warning for unsupported tools", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(noOp);
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "Custom Tool",
+        tool: "Custom Tool",
+        state: "success",
+        message: "Passed",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+    ];
+
+    render(createConfig(tasks, ["Foo", "Bar"]), baseRunOptions);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      chalk.yellow(
+        "Warning: `Foo` and `Bar` tools aren't directly supported; using exit codes only."
+      )
+    );
+  });
+
+  it("uses singular wording for a single unsupported tool warning", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(noOp);
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "Foo",
+        tool: "Foo",
+        state: "success",
+        message: "Passed",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+    ];
+
+    render(createConfig(tasks, ["Foo"]), baseRunOptions);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      chalk.yellow(
+        "Warning: `Foo` tool isn't directly supported; using exit codes only."
+      )
+    );
+  });
+
+  it("uses an Oxford comma when warning about three unsupported tools", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(noOp);
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "Foo",
+        tool: "Foo",
+        state: "success",
+        message: "Passed",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+    ];
+
+    render(createConfig(tasks, ["test", "hello", "world"]), baseRunOptions);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      chalk.yellow(
+        "Warning: `test`, `hello`, and `world` tools aren't directly supported; using exit codes only."
+      )
+    );
+  });
+
+  it("does not print an unsupported-tools warning when all tools are supported", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(noOp);
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "ESLint",
+        tool: "ESLint",
+        state: "success",
+        message: "Passed",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+    ];
+
+    render(createConfig(tasks), baseRunOptions);
+
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("directly supported")
+    );
+  });
+
+  it("uses a failure icon when a task failed without counted issues", () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "Custom Tool",
+        tool: "Custom Tool",
+        state: "failure",
+        message: "Failed - see output below for details",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+    ];
+
+    render(createConfig(tasks, ["Custom Tool"]), baseRunOptions);
+
+    expect(renderTableMock).toHaveBeenCalledWith(tasks, [
+      "❌ Overall",
+      "",
+      "0 issues",
+      "1.0 s",
+    ]);
+  });
+
+  it("uses a failure icon when a finished suite mixes success and failure states", () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    const tasks = [
+      createTaskDouble({
+        label: "Passed Task",
+        tool: "ToolA",
+        state: "success",
+        message: "Passed",
+        startTime: 1_000,
+        endTime: 2_000,
+      }),
+      createTaskDouble({
+        label: "Failed Task",
+        tool: "ToolB",
+        state: "failure",
+        message: "Failed",
+        errors: 1,
+        startTime: 1_200,
+        endTime: 2_200,
+      }),
+    ];
+
+    render(createConfig(tasks), baseRunOptions);
+
+    expect(renderTableMock).toHaveBeenCalledWith(tasks, [
+      "❌ Overall",
+      "",
+      "1 issue (1 error)",
+      "1.2 s",
     ]);
   });
 });

--- a/src/renderers/render.ts
+++ b/src/renderers/render.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 
 import pkg from "../../package.json";
+import { type Config } from "../config/types";
 import { formatDuration, taskStateIcons } from "../helpers";
 import { type RunOptions } from "../runOptions/types";
-import { type Task } from "../task/task";
 import { type FailureDetails } from "../task/types";
 
 import { renderTable } from "./tableRenderer";
@@ -75,13 +75,34 @@ export const printFailureDetails = (
   }
 };
 
+const formatUnsupportedTools = (unsupportedTools: string[]) => {
+  const quotedTools = unsupportedTools.map((tool) => {
+    return `\`${tool}\``;
+  });
+
+  if (quotedTools.length <= 1) {
+    return quotedTools[0] ?? "";
+  }
+
+  if (quotedTools.length === 2) {
+    return `${quotedTools[0]} and ${quotedTools[1]}`;
+  }
+
+  const leadingTools = quotedTools.slice(0, -1).join(", ");
+  const lastTool = quotedTools.at(-1);
+
+  return `${leadingTools}, and ${lastTool}`;
+};
+
 /**
  * Renders the current status of all tasks to the console.
  *
- * @param {Task[]} tasks - Array of tasks to render.
+ * @param {Config} config - Config and task metadata to render.
  * @param {RunOptions} runOptions - Options that influenced the run.
  */
-export const render = (tasks: Task[], runOptions: RunOptions) => {
+export const render = (config: Config, runOptions: RunOptions) => {
+  const { tasks, unsupportedTools } = config;
+
   if (process.stdout.isTTY) {
     console.clear();
   }
@@ -99,6 +120,9 @@ export const render = (tasks: Task[], runOptions: RunOptions) => {
   const suiteFinished = tasks.every((task) => {
     const state = task.getStatus().state;
     return state === "success" || state === "failure";
+  });
+  const hasFailures = tasks.some((task) => {
+    return task.getStatus().state === "failure";
   });
 
   const failures: FailureDetails[] = [];
@@ -147,7 +171,7 @@ export const render = (tasks: Task[], runOptions: RunOptions) => {
   })();
 
   const overallIcon = suiteFinished
-    ? totalIssues === 0
+    ? !hasFailures
       ? taskStateIcons.success
       : taskStateIcons.failure
     : taskStateIcons.running;
@@ -179,6 +203,16 @@ export const render = (tasks: Task[], runOptions: RunOptions) => {
   ];
 
   console.log(renderTable(tasks, overallRow));
+
+  if (unsupportedTools.length > 0) {
+    const verb = unsupportedTools.length === 1 ? "isn't" : "aren't";
+    const noun = unsupportedTools.length === 1 ? "tool" : "tools";
+    console.log(
+      chalk.yellow(
+        `Warning: ${formatUnsupportedTools(unsupportedTools)} ${noun} ${verb} directly supported; using exit codes only.`
+      )
+    );
+  }
 
   if (runOptions.isWatchMode) {
     console.log(

--- a/src/renderers/tableRenderer/tableRenderer.test.ts
+++ b/src/renderers/tableRenderer/tableRenderer.test.ts
@@ -151,16 +151,19 @@ describe("renderTable", () => {
     state,
     message,
     duration,
+    usesExitCodeOnly = false,
   }: {
     label: string;
     tool: string;
     state: "pending" | "running" | "success" | "failure";
     message: string;
     duration: number | null;
+    usesExitCodeOnly?: boolean;
   }) => {
     return {
       label,
       tool,
+      usesExitCodeOnly,
       getStatus: () => {
         return { state, message };
       },
@@ -322,5 +325,20 @@ describe("renderTable", () => {
         "└──────────┴────────┴─────────┴──────┘",
       ].join("\n")
     );
+  });
+
+  it("appends the warning emoji to unsupported tools", () => {
+    const table = renderTable([
+      createTask({
+        label: "test",
+        tool: "test",
+        state: "success",
+        message: "Passed",
+        duration: 27,
+        usesExitCodeOnly: true,
+      }),
+    ]);
+
+    expect(table).toContain("test 🔸");
   });
 });

--- a/src/renderers/tableRenderer/tableRenderer.ts
+++ b/src/renderers/tableRenderer/tableRenderer.ts
@@ -14,6 +14,10 @@ const BORDER_CHARS: Record<BorderLevel, BorderChars> = {
 
 const TABLE_HEADERS = ["Label", "Tool", "Results", "Time"];
 
+const formatToolCell = (task: Task) => {
+  return task.usesExitCodeOnly ? `${task.tool} 🔸` : task.tool;
+};
+
 /**
  * Renders a table with borders, headers, rows, and an optional footer.
  *
@@ -30,7 +34,7 @@ export const renderTable = (tasks: Task[], footerRow?: string[]) => {
         : colorStatusMessage(status.message, status.state);
     return [
       `${taskStateIcons[status.state]} ${task.label}`,
-      task.tool,
+      formatToolCell(task),
       message,
       formatDuration(task.getDuration()),
     ];

--- a/src/runOptions/help.md
+++ b/src/runOptions/help.md
@@ -45,6 +45,9 @@ for global support.
   to point the CLI at a specific file.
 - Each file must export an object with a `tasks` array. Every task entry must
   specify the `tool` name and its `command`, and may provide `fixCommand` overrides.
+- Built-in tools get parser-based issue counts. Other tool names are allowed,
+  but they run in exit-code-only mode and show a warning that they are not
+  directly supported.
 
 Example `.is-it-ready.config.mjs`:
 
@@ -66,7 +69,7 @@ export default {
 
 ### Tool support
 
-Currently, this tool only provides support for the following packages/tools:
+Currently, this tool provides direct parser support for the following tools:
 
 - ESLint
 - Knip
@@ -75,6 +78,10 @@ Currently, this tool only provides support for the following packages/tools:
 - TypeScript
 - Vitest
 
-It also provides support for some npm commands
+It also provides direct parser support for some npm commands:
 
 - npm audit
+
+Other tools may still be configured. When a tool has no built-in parser,
+`is-it-ready` warns once and uses only the command exit code to decide whether
+that task passed or failed.

--- a/src/task/execute.test.ts
+++ b/src/task/execute.test.ts
@@ -4,7 +4,7 @@ import { type Config } from "../config/types";
 import { render } from "../renderers";
 import { type RunOptions } from "../runOptions/types";
 
-import { calculateTotalIssues, runTasks } from "./execute";
+import { calculateTotalIssues, hasTaskFailures, runTasks } from "./execute";
 import { Task } from "./task";
 
 vi.mock("../renderers", () => {
@@ -65,15 +65,16 @@ describe("runTasks", () => {
   it("renders before running tasks and whenever callbacks fire", async () => {
     const firstTask = createTaskDouble("first-tool");
     const secondTask = createTaskDouble("second-tool");
-    const config = {
+    const config: Config = {
+      unsupportedTools: [],
       tasks: [firstTask.task, secondTask.task],
-    } as Config;
+    };
 
     await runTasks(config, baseRunOptions);
 
     expect(renderMock).toHaveBeenCalledTimes(1 + config.tasks.length * 2);
-    renderMock.mock.calls.forEach(([tasksArg, optionsArg]) => {
-      expect(tasksArg).toBe(config.tasks);
+    renderMock.mock.calls.forEach(([configArg, optionsArg]) => {
+      expect(configArg).toBe(config);
       expect(optionsArg).toBe(baseRunOptions);
     });
 
@@ -102,5 +103,41 @@ describe("calculateTotalIssues", () => {
     ];
 
     expect(calculateTotalIssues(tasks)).toBe(7);
+  });
+});
+
+describe("hasTaskFailures", () => {
+  it("returns true when any task status is failure even without counted issues", () => {
+    const tasks = [
+      {
+        getStatus: () => {
+          return { state: "success", message: "Passed" };
+        },
+      },
+      {
+        getStatus: () => {
+          return { state: "failure", message: "Failed" };
+        },
+      },
+    ] as unknown as Task[];
+
+    expect(hasTaskFailures(tasks)).toBe(true);
+  });
+
+  it("returns false when no task has failed", () => {
+    const tasks = [
+      {
+        getStatus: () => {
+          return { state: "success", message: "Passed" };
+        },
+      },
+      {
+        getStatus: () => {
+          return { state: "running", message: "Running..." };
+        },
+      },
+    ] as unknown as Task[];
+
+    expect(hasTaskFailures(tasks)).toBe(false);
   });
 });

--- a/src/task/execute.ts
+++ b/src/task/execute.ts
@@ -11,16 +11,16 @@ import { type Task } from "./task";
  * @param {RunOptions} runOptions - The options to use when running the tasks.
  */
 export const runTasks = async (config: Config, runOptions: RunOptions) => {
-  render(config.tasks, runOptions);
+  render(config, runOptions);
 
   await Promise.all(
     config.tasks.map((task) => {
       return task.execute({
         onStart: () => {
-          render(config.tasks, runOptions);
+          render(config, runOptions);
         },
         onFinish: () => {
-          render(config.tasks, runOptions);
+          render(config, runOptions);
         },
       });
     })
@@ -37,4 +37,16 @@ export const calculateTotalIssues = (tasks: Task[]) => {
   return tasks.reduce((total, task) => {
     return total + task.getTotalErrors() + task.getTotalWarnings();
   }, 0);
+};
+
+/**
+ * Determines whether any task failed, regardless of parser-derived issue counts.
+ *
+ * @param {Task[]} tasks - The tasks to inspect.
+ * @returns {boolean} True when at least one task failed.
+ */
+export const hasTaskFailures = (tasks: Task[]) => {
+  return tasks.some((task) => {
+    return task.getStatus().state === "failure";
+  });
 };

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,4 +1,4 @@
 export { Task } from "./task";
 export { defaultTools } from "./defaultTools";
-export { runTasks, calculateTotalIssues } from "./execute";
+export { runTasks, hasTaskFailures } from "./execute";
 export { startWatcher } from "./watcher";

--- a/src/task/task.test.ts
+++ b/src/task/task.test.ts
@@ -434,6 +434,63 @@ describe("Task", () => {
     expect(task.getTotalWarnings()).toBe(0);
   });
 
+  it("passes unsupported tools when the command exits successfully", async () => {
+    vi.spyOn(helpers, "runCommand").mockResolvedValue({
+      status: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+
+    const task = createMockTask({
+      usesExitCodeOnly: true,
+      parseFailure: () => {
+        return undefined;
+      },
+    });
+
+    await task.execute();
+
+    expect(task.getStatus()).toEqual({ state: "success", message: "Passed" });
+    expect(task.getTotalErrors()).toBe(0);
+    expect(task.getTotalWarnings()).toBe(0);
+  });
+
+  it("fails unsupported tools by exit code without synthetic issue counts", async () => {
+    vi.spyOn(helpers, "runCommand").mockResolvedValue({
+      status: 1,
+      stdout: "failure output",
+      stderr: "",
+    });
+
+    const task = createMockTask({
+      usesExitCodeOnly: true,
+      parseFailure: () => {
+        return undefined;
+      },
+    });
+
+    await task.execute();
+
+    expect(task.getStatus()).toEqual({
+      state: "failure",
+      message: "Failed - see output below for details",
+    });
+    expect(task.getFailures()).toEqual([
+      {
+        label: "Echo Task",
+        tool: "Echo",
+        command: "echo 'Echo command'",
+        errors: undefined,
+        warnings: undefined,
+        summary: undefined,
+        output: "failure output",
+        rawOutput: "failure output",
+      },
+    ]);
+    expect(task.getTotalErrors()).toBe(0);
+    expect(task.getTotalWarnings()).toBe(0);
+  });
+
   it("tracks running status while command is in progress", async () => {
     let resolveRun: (() => void) | undefined;
     vi.spyOn(helpers, "runCommand").mockImplementation(() => {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -12,6 +12,7 @@ export class Task {
   readonly label: string;
   readonly command: string;
   readonly tool: string;
+  readonly usesExitCodeOnly: boolean;
 
   readonly parseFailure: (output: string) => ParsedFailure | undefined;
 
@@ -29,6 +30,7 @@ export class Task {
     this.label = executableCommand.label;
     this.command = executableCommand.command;
     this.tool = config.tool;
+    this.usesExitCodeOnly = config.usesExitCodeOnly ?? false;
 
     this.parseFailure = config.parseFailure;
 
@@ -111,6 +113,10 @@ export class Task {
 
   private recordIssueCounts(parsedFailure?: ParsedFailure | null) {
     if (!parsedFailure) {
+      if (this.usesExitCodeOnly) {
+        return;
+      }
+
       this.totalErrors += 1;
       return;
     }

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -12,6 +12,7 @@ export type ToolConfig = {
   label: string;
   tool: string;
   parseFailure: (output: string) => ParsedFailure | undefined;
+  usesExitCodeOnly?: boolean;
 };
 
 export type TaskConfig = ToolConfig & {

--- a/src/task/watcher.test.ts
+++ b/src/task/watcher.test.ts
@@ -1,15 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type Config } from "../config/types";
 import { type RunOptions } from "../runOptions/types";
 
 import { startWatcher } from "./watcher";
 
-const { watchMock, runTasksMock, calculateTotalIssuesMock } = vi.hoisted(() => {
+const { watchMock, runTasksMock, hasTaskFailuresMock } = vi.hoisted(() => {
   return {
     watchMock: vi.fn(),
     runTasksMock: vi.fn(),
-    calculateTotalIssuesMock: vi.fn(),
+    hasTaskFailuresMock: vi.fn(),
   };
 });
 
@@ -24,7 +23,7 @@ vi.mock("chokidar", () => {
 vi.mock("./execute", () => {
   return {
     runTasks: runTasksMock,
-    calculateTotalIssues: calculateTotalIssuesMock,
+    hasTaskFailures: hasTaskFailuresMock,
   };
 });
 
@@ -48,7 +47,7 @@ describe("startWatcher", () => {
   beforeEach(() => {
     watchMock.mockReset();
     runTasksMock.mockReset();
-    calculateTotalIssuesMock.mockReset();
+    hasTaskFailuresMock.mockReset();
 
     fileChangeHandler = undefined;
     watcher = {
@@ -74,8 +73,9 @@ describe("startWatcher", () => {
 
   it("uses default ignore patterns and reruns tasks on change events", () => {
     const config = {
+      unsupportedTools: [],
       tasks: [],
-    } as Config;
+    };
 
     startWatcher(config, baseRunOptions);
 
@@ -93,8 +93,9 @@ describe("startWatcher", () => {
 
   it("prevents overlapping reruns while tasks are executing", async () => {
     const config = {
+      unsupportedTools: [],
       tasks: [],
-    } as Config;
+    };
     let resolveRun: (() => void) | undefined;
 
     runTasksMock.mockImplementation(() => {
@@ -120,9 +121,10 @@ describe("startWatcher", () => {
 
   it("closes the watcher and exits with correct status when interrupted", () => {
     const config = {
+      unsupportedTools: [],
       tasks: [],
-    } as Config;
-    calculateTotalIssuesMock.mockReturnValueOnce(2).mockReturnValueOnce(0);
+    };
+    hasTaskFailuresMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
 
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
       return undefined;
@@ -141,7 +143,7 @@ describe("startWatcher", () => {
 
     signalHandlers.SIGINT();
     expect(watcher.close).toHaveBeenCalledTimes(1);
-    expect(calculateTotalIssuesMock).toHaveBeenCalledWith(config.tasks);
+    expect(hasTaskFailuresMock).toHaveBeenCalledWith(config.tasks);
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     exitSpy.mockClear();

--- a/src/task/watcher.ts
+++ b/src/task/watcher.ts
@@ -3,7 +3,7 @@ import chokidar from "chokidar";
 import { type Config } from "../config/types";
 import { type RunOptions } from "../runOptions/types";
 
-import { calculateTotalIssues, runTasks } from "./execute";
+import { hasTaskFailures, runTasks } from "./execute";
 
 let isRunning = false;
 
@@ -47,7 +47,7 @@ export const startWatcher = (config: Config, runOptions: RunOptions) => {
 
   const handleExit = () => {
     void watcher.close();
-    process.exit(calculateTotalIssues(config.tasks) > 0 ? 1 : 0);
+    process.exit(hasTaskFailures(config.tasks) ? 1 : 0);
   };
 
   process.on("SIGINT", handleExit);


### PR DESCRIPTION
# Pull Request

## Summary

This PR changes unsupported tool handling so `is-it-ready` no longer fails during config loading when a task uses a tool without a built-in parser.

Unsupported tools now run normally, show a warning that they are not directly supported, and use exit codes only for pass/fail. They are also marked inline in the `Tool` column as `<tool> 🔸`.

## Reasoning

### Why is this change needed?

Previously, configuring a tool without a parser caused `is-it-ready` to error before running the task. That made custom integrations unusable even when the command itself had a reliable exit code.

This PR fixes that by allowing unsupported tools to run while making the fallback behavior explicit in the UI.

### What are the benefits?

- custom tools can be included in `is-it-ready` configs without adding parser support first
- users get a clear warning that unsupported tools rely on exit codes only
- suite exit behavior is now correct even when a failed task has no parser-derived issue count
- supported tools keep their existing parser-based behavior unchanged

## Screenshots (Optional)

<img width="759" height="351" alt="image" src="https://github.com/user-attachments/assets/d0ad97a4-d0fc-4acf-b1fb-8fbf53768759" />