### PR TITLE
fix: update task state icons to use consistent symbols

### DIFF
--- a/src/helpers/icons.test.ts
+++ b/src/helpers/icons.test.ts
@@ -7,8 +7,8 @@ describe("taskStateIcons", () => {
     expect(taskStateIcons).toEqual({
       pending: "  ",
       running: "⏳",
-      success: "✅",
-      failure: "❌",
+      success: "🟢",
+      failure: "🔴",
     });
   });
 });

--- a/src/helpers/icons.ts
+++ b/src/helpers/icons.ts
@@ -3,6 +3,6 @@ import { type TaskState } from "../task/types";
 export const taskStateIcons: Record<TaskState, string> = {
   pending: "  ",
   running: "⏳",
-  success: "✅",
-  failure: "❌",
+  success: "🟢",
+  failure: "🔴",
 };

--- a/src/renderers/render.test.ts
+++ b/src/renderers/render.test.ts
@@ -411,7 +411,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "❌ Overall",
+      "🔴 Overall",
       "",
       "3 issues (2 errors, 1 warning)",
       "1.0 s",
@@ -450,7 +450,7 @@ describe("render", () => {
       "(* indicates fix mode; some tasks will automatically apply fixes to your code)\n"
     );
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "✅ Overall",
+      "🟢 Overall",
       "",
       "0 issues",
       "1.0 s",
@@ -485,7 +485,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "❌ Overall",
+      "🔴 Overall",
       "",
       "2 issues (1 error, 1 warning)",
       "10 ms",
@@ -570,7 +570,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "✅ Overall",
+      "🟢 Overall",
       "",
       "0 issues",
       "3.0 s",
@@ -598,7 +598,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "✅ Overall",
+      "🟢 Overall",
       "",
       "0 issues",
       "0 ms",
@@ -626,7 +626,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "❌ Overall",
+      "🔴 Overall",
       "",
       "2 issues (2 warnings)",
       "100 ms",
@@ -669,7 +669,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "✅ Overall",
+      "🟢 Overall",
       "",
       "0 issues",
       "1.0 s",
@@ -704,7 +704,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "✅ Overall",
+      "🟢 Overall",
       "",
       "0 issues",
       "1.0 s",
@@ -837,7 +837,7 @@ describe("render", () => {
     render(createConfig(tasks, ["Custom Tool"]), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "❌ Overall",
+      "🔴 Overall",
       "",
       "0 issues",
       "1.0 s",
@@ -873,7 +873,7 @@ describe("render", () => {
     render(createConfig(tasks), baseRunOptions);
 
     expect(renderTableMock).toHaveBeenCalledWith(tasks, [
-      "❌ Overall",
+      "🔴 Overall",
       "",
       "1 issue (1 error)",
       "1.2 s",

--- a/src/renderers/tableRenderer/tableRenderer.test.ts
+++ b/src/renderers/tableRenderer/tableRenderer.test.ts
@@ -184,17 +184,17 @@ describe("renderTable", () => {
           duration: 120,
         }),
       ],
-      ["✅ Overall", "", "0 issues", "120 ms"]
+      ["🟢 Overall", "", "0 issues", "120 ms"]
     );
 
     expect(table).toContain("Label");
     expect(table).toContain("Tool");
     expect(table).toContain("Results");
     expect(table).toContain("Time");
-    expect(table).toContain("✅ Lint");
+    expect(table).toContain("🟢 Lint");
     expect(table).toContain("OK");
     expect(table).toContain("120 ms");
-    expect(table).toContain("✅ Overall");
+    expect(table).toContain("🟢 Overall");
   });
 
   it("uses footer values when they define the widest column", () => {


### PR DESCRIPTION
# Pull Request

## Summary

Updates task state icons to use a consistent set of symbols across rendering output and related tests.

## Reasoning

### Why is this change needed?

The task state output was using inconsistent symbols, which made the rendered status display less uniform.

### What are the benefits?

This makes task status output more consistent and keeps the renderer tests aligned with the updated icon set.
